### PR TITLE
Added RS232 vs RS485 support

### DIFF
--- a/yaqd_vici/_vici_two_position.py
+++ b/yaqd_vici/_vici_two_position.py
@@ -19,7 +19,6 @@ class ViciTwoPosition(UsesUart, UsesSerial, IsDiscrete, HasPosition, IsDaemon):
             self._serial = aserial.ASerial()
             self._serial.port = self._config["serial_port"]
             self._serial.baudrate = self._config["baud_rate"]
-            self._serial.interface = self._config["interface"]
             self._serial.eol = b"\r"
             self._serial.open()
             ViciTwoPosition._serial_objects[self._config["serial_port"]] = self._serial

--- a/yaqd_vici/_vici_two_position.py
+++ b/yaqd_vici/_vici_two_position.py
@@ -19,6 +19,7 @@ class ViciTwoPosition(UsesUart, UsesSerial, IsDiscrete, HasPosition, IsDaemon):
             self._serial = aserial.ASerial()
             self._serial.port = self._config["serial_port"]
             self._serial.baudrate = self._config["baud_rate"]
+            self._serial.interface = self._config["interface"]
             self._serial.eol = b"\r"
             self._serial.open()
             ViciTwoPosition._serial_objects[self._config["serial_port"]] = self._serial
@@ -40,8 +41,12 @@ class ViciTwoPosition(UsesUart, UsesSerial, IsDiscrete, HasPosition, IsDaemon):
         else:
             to_write += "CW"  # position A
         # finish
-        self._serial.write((to_write + "\r").encode())
-        self._serial.flush()
+        if self._config["interface"] == "RS485":
+            self._serial.write(("/Z" + to_write + "\r").encode())
+            self._serial.flush()
+        else:
+            self._serial.write((to_write + "\r").encode())
+            self._serial.flush()
 
     async def update_state(self):
         while True:

--- a/yaqd_vici/vici-two-position.avpr
+++ b/yaqd_vici/vici-two-position.avpr
@@ -4,10 +4,6 @@
             "origin": "uses-uart",
             "type": "int"
         },
-        "interface":{
-            "default": "RS232",
-            "type": "string",
-        },
         "device_id": {
             "default": null,
             "doc": "VICI device ID, an integer from 0 to 9. If unspecified, will assume no ID. You must manually program your control modules with IDs, yaq will not attempt to apply IDs.",

--- a/yaqd_vici/vici-two-position.avpr
+++ b/yaqd_vici/vici-two-position.avpr
@@ -259,13 +259,13 @@
     },
     "properties": {
         "destination": {
-            "control_kind": "hinted",
+            "control_kind": "normal",
             "dynamic": true,
             "getter": "get_destination",
             "limits_getter": null,
             "options_getter": null,
             "record_kind": "data",
-            "setter": "set_position",
+            "setter": null,
             "type": "double",
             "units_getter": "get_units"
         },
@@ -276,7 +276,7 @@
             "limits_getter": null,
             "options_getter": null,
             "record_kind": "data",
-            "setter": null,
+            "setter": "set_position",
             "type": "double",
             "units_getter": "get_units"
         },

--- a/yaqd_vici/vici-two-position.avpr
+++ b/yaqd_vici/vici-two-position.avpr
@@ -4,6 +4,10 @@
             "origin": "uses-uart",
             "type": "int"
         },
+        "interface":{
+            "default": "RS232",
+            "type": "string",
+        },
         "device_id": {
             "default": null,
             "doc": "VICI device ID, an integer from 0 to 9. If unspecified, will assume no ID. You must manually program your control modules with IDs, yaq will not attempt to apply IDs.",

--- a/yaqd_vici/vici-two-position.avpr
+++ b/yaqd_vici/vici-two-position.avpr
@@ -4,10 +4,6 @@
             "origin": "uses-uart",
             "type": "int"
         },
-        "interface":{
-            "default": "RS232",
-            "type": "string",
-        },
         "device_id": {
             "default": null,
             "doc": "VICI device ID, an integer from 0 to 9. If unspecified, will assume no ID. You must manually program your control modules with IDs, yaq will not attempt to apply IDs.",
@@ -32,6 +28,18 @@
             "type": {
                 "type": "map",
                 "values": "double"
+            }
+        },
+        "interface": {
+            "default": "RS232",
+            "doc": "VICI uses slightly different commands for RS232 vs RS485. You must tell yaq if you require RS485 style commands.",
+            "type": {
+                "name": "interface",
+                "symbols": [
+                    "RS232",
+                    "RS485"
+                ],
+                "type": "enum"
             }
         },
         "log_level": {
@@ -251,13 +259,13 @@
     },
     "properties": {
         "destination": {
-            "control_kind": "normal",
+            "control_kind": "hinted",
             "dynamic": true,
             "getter": "get_destination",
             "limits_getter": null,
             "options_getter": null,
             "record_kind": "data",
-            "setter": null,
+            "setter": "set_position",
             "type": "double",
             "units_getter": "get_units"
         },
@@ -268,7 +276,7 @@
             "limits_getter": null,
             "options_getter": null,
             "record_kind": "data",
-            "setter": "set_position",
+            "setter": null,
             "type": "double",
             "units_getter": "get_units"
         },

--- a/yaqd_vici/vici-two-position.toml
+++ b/yaqd_vici/vici-two-position.toml
@@ -20,3 +20,8 @@ default = "__null__"
 
 [config.identifiers]
 default = {"A"=0, "B"=1}
+
+[config.interface]
+doc = "VICI uses slightly different commands for RS232 vs RS485. You must tell yaq if you require RS485 style commands."
+type = {"type"="enum", "name"="interface", "symbols"=["RS232", "RS485"]}
+default = "RS232"


### PR DESCRIPTION
added pre-pend of /Z for all nondefault interfaces of RS485 in config file

TODO:
- [x] add to CHANGELOG
- [x] edit `hardware` field of toml to indicate increased hardware support, rerender avpr
- [x] edit this file https://github.com/yaq-project/yaq-fyi/blob/main/known-hardware.toml to indicate increased hardware support